### PR TITLE
Update privacy policy for analytics tools

### DIFF
--- a/app/src/content/pages/privacy-policy.md
+++ b/app/src/content/pages/privacy-policy.md
@@ -6,15 +6,32 @@ This is a personal blog created and maintained for private and non-commercial pu
 
 ## 1. Data collection
 
-This site uses **Cloudflare server-side analytics** to gather basic information about site usage, such as:
+This site uses two privacy-respecting analytics tools:
 
-- Pages visited  
-- Referring website  
-- Browser type and operating system  
-- General location (country level)  
-- Anonymized IP address  
+### a) Plausible Analytics
 
-This data is collected in aggregate form only and cannot be used to identify you personally.
+Plausible is a **privacy-first, cookie-free analytics platform**. It collects only aggregated, non-personal data to help understand overall traffic and site usage trends.
+
+The following data points are collected:
+
+- **Page URL** - The path and hostname of the visited page
+- **HTTP Referrer** - The previous site that linked to the page (if available)
+- **Browser & version** - Based on the User-Agent string; full string is discarded
+- **Operating system & version** - Based on the User-Agent string; full string is discarded
+- **Device type** - Categorized as desktop, tablet, or mobile
+- **Geographic location** - Country, region, and city (derived from IP address); IP is discarded and never stored
+
+Plausible does not set cookies, does not store personal data, and does not use persistent identifiers.
+
+### b) Cloudflare server-side analytics
+
+The following data points may be collected:
+
+- **Page views and traffic volume** - Used to monitor load, detect unusual patterns, and maintain uptime
+- **Browser & operating system** - Derived from the request headers to identify general trends (e.g. Chrome on Windows)
+- **Geographic location** - Country-level location based on anonymized IP data; full IP addresses are not stored or used for tracking
+
+All Cloudflare data is aggregated and used solely for performance and security analysis.
 
 ## 2. Cookies
 
@@ -23,16 +40,16 @@ For more details, see the [Cookie Policy](/cookie-policy).
 
 ## 3. No personal data
 
-We do not collect, store, or process any personal data such as names, email addresses, or IP addresses that can be linked to you individually. There are no contact forms, comment sections, or login systems on this site.
+We do not collect, store, or process any personal data such as names, email addresses, or identifiable IP addresses. There are no contact forms, comment sections, or login systems on this site.
 
 ## 4. Data usage
 
-The anonymized usage data collected via Cloudflare is used solely for the purpose of understanding traffic patterns and improving the performance and stability of the site.
+The anonymized usage data collected through Plausible and Cloudflare is used solely to understand traffic patterns, protect site integrity, and improve performance.
 
 ## 5. Contact
 
-If you have any questions about this policy, you can contact the site owner at:  
+If you have any questions about this policy, you can contact the site owner at:
 `admin[at]hashtagsheep[dot]com`
 
 ---
-Last updated: 2025-07-08
+Last updated: 2025-07-24


### PR DESCRIPTION
Revise the privacy policy to include details about the use of Plausible Analytics alongside Cloudflare server-side analytics.